### PR TITLE
Re-enable auto calibration, remove extensions.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+.vscode/extensions.json
 .vscode/ipch
 _constants.h

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,0 @@
-{
-    // See http://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": [
-        "platformio.platformio-ide"
-    ]
-}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,13 +88,13 @@ void setup() {
 
     // Start SCD30 after BSEC to allow it to
     // configure clock streching correctly on ESP8266
-    if (scd30.begin(Wire, false)) {
+    if (scd30.begin(Wire, true /*auto calibration*/)) {
         Serial.println("SCD30 detected");
     } else {
         Serial.println("SCD30 not detected on first attempt");
         //Give it 2s to boot and then try again
         delay(2000);
-        if (scd30.begin(Wire, false)) {
+        if (scd30.begin(Wire, true /*auto calibration*/)) {
           Serial.println("SCD30 detected on second attempt");
         }
     }


### PR DESCRIPTION
Auto calibration seems to make more sense than forced calibration.

Also VS Code (or PlatformIO?) seems to regenerate the extension.json with CRLF line sequence even though Git converted it to LF leading to annoying unstaged changes. I guess you already ran into the same behavior :smile: 